### PR TITLE
Add/Update Necessary ConnectorName Values for Multiple MCP Servers

### DIFF
--- a/partners/servers/azure-databricks-mcp-server.json
+++ b/partners/servers/azure-databricks-mcp-server.json
@@ -39,5 +39,6 @@
       "flows": ["authorizationCode"]
     }
   },
-  "authSchemas":[ "OAuth2"]
+  "authSchemas":[ "OAuth2"],
+  "connectorName": "foundrydatabricksmcp"
 }

--- a/partners/servers/box-mcp-server.json
+++ b/partners/servers/box-mcp-server.json
@@ -31,5 +31,6 @@
             "tokenUrl": "https://api.box.com/oauth2/token",
             "scopes":[]
         }
-    }
+    },
+    "connectorName": "foundryboxmcp"
 }

--- a/partners/servers/github-mcp-server.json
+++ b/partners/servers/github-mcp-server.json
@@ -58,7 +58,7 @@
     "categories": "Developer Tools",
     "vendor": "Microsoft",
     "visibility": "true",
-    "connectorName": "githubmcp",
+    "connectorName": "foundrygithubmcp",
     "securitySchemes": {
         "githubOauth": {
             "type": "oauth2",

--- a/partners/servers/neon-mcp-server.json
+++ b/partners/servers/neon-mcp-server.json
@@ -31,5 +31,6 @@
             "tokenUrl": "https://oauth2.neon.tech/oauth2/token",
             "scopes": []
         }
-    }
+    },
+    "connectorName": "foundryneonmcp"
 }


### PR DESCRIPTION
Update the `connectorName` hint for the following MCP servers to better follow the `foundry{service}mcp` template:
- GitHub
- Box
- Neon
- Azure Databricks