### PR TITLE
Add Miro MCP server

### DIFF
--- a/partners/servers/miro-mcp-server.json
+++ b/partners/servers/miro-mcp-server.json
@@ -56,7 +56,7 @@
       "type": "oauth2",
       "description": "Authenticate with Miro using OAuth2 authorization code flow.",
       "flows": ["authorizationCode"],
-      "authorizationUrl": "https://mcp.miro.com/auth",
+      "authorizationUrl": "https://mcp.miro.com/authorize",
       "tokenUrl": "https://mcp.miro.com/token",
       "scopes": ["boards:read", "boards:write"]
     }

--- a/partners/servers/miro-mcp-server.json
+++ b/partners/servers/miro-mcp-server.json
@@ -1,0 +1,66 @@
+{
+  "name": "miro-mcp-server",
+  "title": "Miro",
+  "summary": "Official Miro MCP server for visual collaboration - create diagrams, docs, and tables. Manage and extract context from Miro boards.",
+  "description": "Official Miro MCP server that enables AI assistants to interact with Miro's visual collaboration platform. Supports board management, AI-powered diagram generation, context extraction for code generation, and board insights. Connects to Miro's remote MCP endpoint using streamable HTTP transport with OAuth2 authentication.",
+  "kind": "mcp",
+  "vendor": "Partner",
+  "icon": "https://avatars.githubusercontent.com/miroapp?s=64",
+  "license": {
+    "name": "Miro Terms of Service",
+    "url": "https://miro.com/legal/terms-of-service/"
+  },
+  "externalDocumentation": {
+    "title": "Miro MCP Server Documentation",
+    "url": "https://developers.miro.com/docs/miro-mcp"
+  },
+  "repository": {
+    "url": "https://github.com/miroapp/miro-ai",
+    "source": "github"
+  },
+  "remote": "https://mcp.miro.com",
+  "remoteType": "streamable-http",
+  "supportContactInfo": {
+    "name": "Miro Developer Support",
+    "url": "https://developers.miro.com"
+  },
+  "visibility": "true",
+  "categories": "Collaboration",
+  "useCases": [
+    {
+      "name": "AI diagram generation",
+      "description": "Generate diagrams, flowcharts, and visual representations on Miro boards using AI-powered tools for architecture planning and documentation."
+    },
+    {
+      "name": "Context to code",
+      "description": "Extract structured context from Miro boards to inform code generation, enabling developers to translate visual designs and documentation into implementation."
+    },
+    {
+      "name": "Board insights and analysis",
+      "description": "Analyze board content and structure to generate insights, summaries, and actionable information from visual collaboration artifacts."
+    },
+    {
+      "name": "Brainstorming facilitation",
+      "description": "Guide brainstorming sessions by creating and organizing content on Miro boards, helping teams ideate and structure their ideas visually."
+    }
+  ],
+  "tags": [
+    "collaboration",
+    "whiteboard",
+    "diagrams",
+    "visual-collaboration",
+    "brainstorming"
+  ],
+  "securitySchemes": {
+    "miroOAuth": {
+      "type": "oauth2",
+      "description": "Authenticate with Miro using OAuth2 authorization code flow.",
+      "flows": ["authorizationCode"],
+      "authorizationUrl": "https://mcp.miro.com/auth",
+      "tokenUrl": "https://mcp.miro.com/token",
+      "scopes": ["boards:read", "boards:write"]
+    }
+  },
+  "versionName": "original",
+  "customProperties": { "x-ms-preview": true }
+}


### PR DESCRIPTION
## Summary

- Adds the official Miro MCP server (`miro-mcp-server.json`) to the partner registry
- Miro's remote MCP endpoint at `https://mcp.miro.com` enables AI assistants to interact with Miro's visual collaboration platform
- Supports board management, AI-powered diagram generation, context extraction for code generation, board insights, and brainstorming facilitation
- Uses streamable HTTP transport with OAuth2 authentication

## Test plan

- [x] Verified the Miro MCP server is accessible and functional at `https://mcp.miro.com`
- [x] Tested integration with Azure AI Foundry to confirm the server works with the Foundry registry
- [x] Validated JSON against the partner `server-schema.json`

Made with [Cursor](https://cursor.com)