### PR TITLE
Add turbopuffer MCP server

### DIFF
--- a/partners/servers/turbopuffer-mcp-server.json
+++ b/partners/servers/turbopuffer-mcp-server.json
@@ -2,7 +2,7 @@
     "name": "turbopuffer-mcp-server",
     "title": "turbopuffer",
     "summary": "Connect to turbopuffer for serverless vector and full-text search over your data.",
-    "description": "The turbopuffer MCP server connects AI agents to turbopuffer, a serverless search engine built on object storage. Query namespaces using vector similarity search, BM25 full-text search, hybrid search, and attribute filtering. Upsert, delete, and manage documents across namespaces. Fast, 10x cheaper, and extremely scalable.",
+    "description": "The turbopuffer MCP server connects AI tools to turbopuffer, a serverless search engine built on object storage. Query namespaces using vector similarity search, BM25 full-text search, hybrid search, and attribute filtering. Upsert, delete, and manage documents across namespaces. Fast, 10x cheaper, and extremely scalable.",
     "kind": "mcp",
     "packages": [],
     "icon": "https://avatars.githubusercontent.com/turbopuffer?s=64",

--- a/partners/servers/turbopuffer-mcp-server.json
+++ b/partners/servers/turbopuffer-mcp-server.json
@@ -2,7 +2,7 @@
     "name": "turbopuffer-mcp-server",
     "title": "turbopuffer",
     "summary": "Connect to turbopuffer for fast, scalable vector and full-text search over your data \u2014 serverless, built on object storage, and 10x cheaper.",
-    "description": "The turbopuffer MCP server connects AI agents to turbopuffer, a serverless search engine built on object storage. Query namespaces using vector similarity search, BM25 full-text search, hybrid search, and attribute filtering. Upsert, delete, and manage documents across namespaces. Fast, 10x cheaper, and extremely scalable.",
+    "description": "Lets AI query and manage data in turbopuffer, a serverless search engine built on object storage. Supports vector similarity search, BM25 full-text search, hybrid search, and attribute filtering across namespaces.",
     "kind": "mcp",
     "packages": [],
     "icon": "https://turbopuffer.com/_next/static/media/logo_header_darkbg.435dd040.svg",
@@ -12,16 +12,16 @@
     },
     "useCases": [
         {
-            "name": "Search Infrastructure",
-            "description": "Power semantic search, BM25 full-text search, and hybrid search over billions of documents with sub-10ms cached latency, backed by object storage for cost-efficient scaling."
+            "name": "Search and retrieval",
+            "description": "Perform vector, full-text, and hybrid searches across namespaces and return ranked results for developer and agentic workflows."
         },
         {
-            "name": "RAG Pipelines",
-            "description": "Build retrieval-augmented generation pipelines by connecting AI agents to turbopuffer for fast, scalable context retrieval over large document collections."
+            "name": "Context-aware generation",
+            "description": "Give AI agents fast, scalable access to your data for retrieval-augmented generation without managing infrastructure."
         },
         {
-            "name": "Retrieval",
-            "description": "Efficiently narrow millions of documents down to tens or hundreds for downstream processing, reranking, or generation using vector similarity and attribute filtering."
+            "name": "Data ingestion and management",
+            "description": "Upsert, update, and delete documents across namespaces to keep your search index current from within agentic workflows."
         }
     ],
     "externalDocumentation": {

--- a/partners/servers/turbopuffer-mcp-server.json
+++ b/partners/servers/turbopuffer-mcp-server.json
@@ -48,6 +48,6 @@
         "url": "https://turbopuffer.com/contact/support"
     },
     "customProperties": {
-        "x-ms-preview": false
+        "x-ms-preview": true
     }
 }

--- a/partners/servers/turbopuffer-mcp-server.json
+++ b/partners/servers/turbopuffer-mcp-server.json
@@ -1,11 +1,11 @@
 {
     "name": "turbopuffer-mcp-server",
     "title": "turbopuffer",
-    "summary": "Connect to turbopuffer for serverless vector and full-text search over your data.",
+    "summary": "Connect to turbopuffer for fast, scalable vector and full-text search over your data \u2014 serverless, built on object storage, and 10x cheaper.",
     "description": "The turbopuffer MCP server connects AI agents to turbopuffer, a serverless search engine built on object storage. Query namespaces using vector similarity search, BM25 full-text search, hybrid search, and attribute filtering. Upsert, delete, and manage documents across namespaces. Fast, 10x cheaper, and extremely scalable.",
     "kind": "mcp",
     "packages": [],
-    "icon": "https://avatars.githubusercontent.com/turbopuffer?s=64",
+    "icon": "https://turbopuffer.com/_next/static/media/logo_header_darkbg.435dd040.svg",
     "license": {
         "name": "turbopuffer Terms of Service",
         "url": "https://turbopuffer.com/terms"
@@ -28,7 +28,15 @@
         "title": "turbopuffer Documentation",
         "url": "https://turbopuffer.com/docs"
     },
-    "tags": ["search", "embeddings", "rag", "full-text-search", "vector-search", "hybrid-search", "vector-database"],
+    "tags": [
+        "search",
+        "embeddings",
+        "rag",
+        "full-text-search",
+        "vector-search",
+        "hybrid-search",
+        "vector-database"
+    ],
     "vendor": "Partner",
     "categories": "Databases",
     "visibility": "true",

--- a/partners/servers/turbopuffer-mcp-server.json
+++ b/partners/servers/turbopuffer-mcp-server.json
@@ -1,0 +1,53 @@
+{
+    "name": "turbopuffer-mcp-server",
+    "title": "turbopuffer",
+    "summary": "Connect to turbopuffer for serverless vector and full-text search over your data.",
+    "description": "The turbopuffer MCP server connects AI agents to turbopuffer, a serverless search engine built on object storage. Query namespaces using vector similarity search, BM25 full-text search, hybrid search, and attribute filtering. Upsert, delete, and manage documents across namespaces. Fast, 10x cheaper, and extremely scalable.",
+    "kind": "mcp",
+    "packages": [],
+    "icon": "https://avatars.githubusercontent.com/turbopuffer?s=64",
+    "license": {
+        "name": "turbopuffer Terms of Service",
+        "url": "https://turbopuffer.com/terms"
+    },
+    "useCases": [
+        {
+            "name": "Semantic Search",
+            "description": "Query your data using vector similarity, BM25 full-text search, or hybrid search with attribute filtering to find the most relevant documents."
+        },
+        {
+            "name": "Data Management",
+            "description": "Upsert, delete, and manage documents stored in turbopuffer namespaces directly from AI agent workflows."
+        },
+        {
+            "name": "RAG Pipelines",
+            "description": "Build retrieval-augmented generation pipelines by connecting AI agents to turbopuffer for context retrieval over large document collections."
+        }
+    ],
+    "externalDocumentation": {
+        "title": "turbopuffer Documentation",
+        "url": "https://turbopuffer.com/docs"
+    },
+    "tags": ["search", "embeddings", "rag", "full-text-search", "vector-search", "hybrid-search"],
+    "vendor": "Partner",
+    "categories": "Databases",
+    "visibility": "true",
+    "remote": "https://turbopuffer.stlmcp.com/",
+    "remoteType": "streamable-http",
+    "versionName": "original",
+    "securitySchemes": {
+        "apiKeyAuth": {
+            "type": "apiKey",
+            "description": "Authenticate with your turbopuffer API key.",
+            "in": "header",
+            "name": "Authorization"
+        }
+    },
+    "supportContactInfo": {
+        "name": "turbopuffer Support",
+        "url": "https://turbopuffer.com/contact/support"
+    },
+    "customProperties": {
+        "x-ms-preview": false
+    }
+}

--- a/partners/servers/turbopuffer-mcp-server.json
+++ b/partners/servers/turbopuffer-mcp-server.json
@@ -2,7 +2,7 @@
     "name": "turbopuffer-mcp-server",
     "title": "turbopuffer",
     "summary": "Connect to turbopuffer for fast, scalable vector and full-text search over your data \u2014 serverless, built on object storage, and 10x cheaper.",
-    "description": "Lets AI query and manage data in turbopuffer, a serverless search engine built on object storage. Supports vector similarity search, BM25 full-text search, hybrid search, and attribute filtering across namespaces.",
+    "description": "Perform vector, full-text, and hybrid search over your data with turbopuffer, a serverless search engine built on object storage.",
     "kind": "mcp",
     "packages": [],
     "icon": "https://turbopuffer.com/_next/static/media/logo_header_darkbg.435dd040.svg",

--- a/partners/servers/turbopuffer-mcp-server.json
+++ b/partners/servers/turbopuffer-mcp-server.json
@@ -12,16 +12,16 @@
     },
     "useCases": [
         {
-            "name": "Semantic Search",
-            "description": "Query your data using vector similarity, BM25 full-text search, or hybrid search with attribute filtering to find the most relevant documents."
-        },
-        {
-            "name": "Data Management",
-            "description": "Upsert, delete, and manage documents stored in turbopuffer namespaces directly from AI agent workflows."
+            "name": "Search Infrastructure",
+            "description": "Power semantic search, BM25 full-text search, and hybrid search over billions of documents with sub-10ms cached latency, backed by object storage for cost-efficient scaling."
         },
         {
             "name": "RAG Pipelines",
-            "description": "Build retrieval-augmented generation pipelines by connecting AI agents to turbopuffer for context retrieval over large document collections."
+            "description": "Build retrieval-augmented generation pipelines by connecting AI agents to turbopuffer for fast, scalable context retrieval over large document collections."
+        },
+        {
+            "name": "Retrieval",
+            "description": "Efficiently narrow millions of documents down to tens or hundreds for downstream processing, reranking, or generation using vector similarity and attribute filtering."
         }
     ],
     "externalDocumentation": {

--- a/partners/servers/turbopuffer-mcp-server.json
+++ b/partners/servers/turbopuffer-mcp-server.json
@@ -2,7 +2,7 @@
     "name": "turbopuffer-mcp-server",
     "title": "turbopuffer",
     "summary": "Connect to turbopuffer for serverless vector and full-text search over your data.",
-    "description": "The turbopuffer MCP server connects AI tools to turbopuffer, a serverless search engine built on object storage. Query namespaces using vector similarity search, BM25 full-text search, hybrid search, and attribute filtering. Upsert, delete, and manage documents across namespaces. Fast, 10x cheaper, and extremely scalable.",
+    "description": "The turbopuffer MCP server connects AI agents to turbopuffer, a serverless search engine built on object storage. Query namespaces using vector similarity search, BM25 full-text search, hybrid search, and attribute filtering. Upsert, delete, and manage documents across namespaces. Fast, 10x cheaper, and extremely scalable.",
     "kind": "mcp",
     "packages": [],
     "icon": "https://avatars.githubusercontent.com/turbopuffer?s=64",
@@ -28,7 +28,7 @@
         "title": "turbopuffer Documentation",
         "url": "https://turbopuffer.com/docs"
     },
-    "tags": ["search", "embeddings", "rag", "full-text-search", "vector-search", "hybrid-search"],
+    "tags": ["search", "embeddings", "rag", "full-text-search", "vector-search", "hybrid-search", "vector-database"],
     "vendor": "Partner",
     "categories": "Databases",
     "visibility": "true",


### PR DESCRIPTION
## Summary
- Adds `turbopuffer-mcp-server.json` to `partners/servers/`
- turbopuffer is a serverless vector and full-text search engine built on object storage
- Remote MCP server via streamable-http at `https://turbopuffer.stlmcp.com/`
- Supports vector similarity search, BM25 full-text search, hybrid search, and attribute filtering
- API key authentication

## Checklist
- [x] JSON validates against `partners/server-schema.json`
- [x] All required fields populated
- [x] `vendor` set to `Partner`
- [x] `x-ms-preview` set to `true`