### PR TITLE
Update audience to per-server client IDs for Work IQ and Admin MCP servers

### DIFF
--- a/partners/servers/a365-admin-mcp-server.json
+++ b/partners/servers/a365-admin-mcp-server.json
@@ -63,7 +63,7 @@
     }
   },
   "authSchemas":["OAuth2"],
-  "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1",
+  "audience": "2dbeefeb-6462-48a4-abe6-1c4989699319",
   "versionName": "original",
   "customProperties": { "x-ms-preview": true }
 }

--- a/partners/servers/a365-calender-mcp-server.json
+++ b/partners/servers/a365-calender-mcp-server.json
@@ -63,7 +63,7 @@
     }
   },
   "authSchemas":["OAuth2"],
-  "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1",
+  "audience": "910333d2-47e9-43ca-981f-6df2f4531ef4",
   "versionName": "original",
   "customProperties": { "x-ms-preview": true },
   "tags": ["workiq"]

--- a/partners/servers/a365-copilot-search-mcp-server.json
+++ b/partners/servers/a365-copilot-search-mcp-server.json
@@ -59,7 +59,7 @@
     }
   },
   "authSchemas":["OAuth2"],
-  "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1",
+  "audience": "ab7c82de-7946-4454-ac28-70249d17c95e",
   "versionName": "original",
   "customProperties": { "x-ms-preview": true },
   "tags": ["workiq"]

--- a/partners/servers/a365-mail-mcp-server.json
+++ b/partners/servers/a365-mail-mcp-server.json
@@ -55,7 +55,7 @@
     }
   },
   "authSchemas":["OAuth2"],
-  "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1",
+  "audience": "16b1878d-62c7-4009-aa25-68989d63bbad",
   "versionName": "original",
   "customProperties": { "x-ms-preview": true },
   "tags": ["workiq"]

--- a/partners/servers/a365-onedrive-mcp-server.json
+++ b/partners/servers/a365-onedrive-mcp-server.json
@@ -87,7 +87,7 @@
     }
   },
   "authSchemas":["OAuth2"],
-  "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1",
+  "audience": "b0b2a2bb-6361-4549-a00c-a018417eb8e2",
   "versionName": "original",
   "customProperties": { "x-ms-preview": true },
   "tags": ["workiq"]

--- a/partners/servers/a365-sharepoint-mcp-server.json
+++ b/partners/servers/a365-sharepoint-mcp-server.json
@@ -155,7 +155,7 @@
     }
   },
   "authSchemas":["OAuth2"],
-  "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1",
+  "audience": "292cff14-c0e8-4116-9e3b-99934ae05766",
   "versionName": "original",
   "customProperties": { "x-ms-preview": true },
   "tags": ["workiq"]

--- a/partners/servers/a365-teams-mcp-server.json
+++ b/partners/servers/a365-teams-mcp-server.json
@@ -55,7 +55,7 @@
     }
   },
   "authSchemas":["OAuth2"],
-  "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1",
+  "audience": "ce5029ee-c1d3-45c0-bdcc-efb5a4245687",
   "versionName": "original",
   "customProperties": { "x-ms-preview": true },
   "tags": ["workiq"]

--- a/partners/servers/a365-user-mcp-server.json
+++ b/partners/servers/a365-user-mcp-server.json
@@ -55,7 +55,7 @@
     }
   },
   "authSchemas":["OAuth2"],
-  "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1",
+  "audience": "147dc821-b413-44c0-8009-1a3098378012",
   "versionName": "original",
   "customProperties": { "x-ms-preview": true },
   "tags": ["workiq"]

--- a/partners/servers/a365-word-mcp-server.json
+++ b/partners/servers/a365-word-mcp-server.json
@@ -51,7 +51,7 @@
     }
   },
   "authSchemas":["OAuth2"],
-  "audience": "ea9ffc3e-8a23-4a7d-836d-234d7c7565c1",
+  "audience": "c2d0c2b6-8013-4346-9f8b-b81d3b754a29",
   "versionName": "original",
   "customProperties": { "x-ms-preview": true },
   "tags": ["workiq"]


### PR DESCRIPTION
## Summary
- Updates the `audience` field from a shared client ID to unique per-server client IDs for Work IQ and Admin MCP servers
- Each server now uses its own dedicated client ID for authentication

## Test plan
- [ ] Verify each server's audience value matches the expected per-server client ID
- [ ] Confirm OAuth flows work correctly with the new per-server audience values

🤖 Generated with [Claude Code](https://claude.com/claude-code)