### PR TITLE
Update mcp_CalendarTools MCP server entry

### DIFF
--- a/partners/servers/CodeBased/mcp_CalendarTools/server.json
+++ b/partners/servers/CodeBased/mcp_CalendarTools/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "com.microsoft/workiq-calendartools",
+  "title": "Work IQ Calendar \u0026 Meetings MCP Server",
+  "description": "Use this MCP server for calendar operations: create, update, retrieve, delete, manage invites;...",
+  "version": "1.0.0",
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://agent365.svc.cloud.microsoft/agents/tenants/{tenant_id}/servers/mcp_CalendarTools",
+      "variables": {
+        "tenant_id": {
+          "description": "Microsoft Entra tenant ID",
+          "isRequired": true
+        }
+      }
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/bap-microsoft/MCP-Platform/",
+    "source": "github"
+  }
+}


### PR DESCRIPTION
Automated update from MCP-Platform Azure/MCP PR pipeline (build 163722696).

Source: bap-microsoft/MCP-Platform @ d5c971f03166350d7df5cf36c4216eadcb207482
Generated by: ServerJsonGenerator (--schema foundry)

This PR updates the Azure/MCP partner catalog entry for **mcp_CalendarTools**.

Authored by: mcpbot-poc (bot account, POC).