### PR TITLE
Add AgentIdentity as authSchema option for Sentinel MCP

### DIFF
--- a/partners/servers/microsoft-sentinel-data-exploration-mcp-server.json
+++ b/partners/servers/microsoft-sentinel-data-exploration-mcp-server.json
@@ -50,7 +50,7 @@
     }
   },
   "visibility": "true",
-  "authSchemas":["OAuth2"],
+  "authSchemas":["OAuth2","AgentIdentity"],
   "audience": "4500ebfb-89b6-4b14-a480-7f749797bfcd",
   "customProperties": { "x-ms-preview": true }
 }

--- a/partners/servers/microsoft-sentinel-graph-mcp-server.json
+++ b/partners/servers/microsoft-sentinel-graph-mcp-server.json
@@ -46,7 +46,7 @@
     }
   },
   "visibility": "true",
-  "authSchemas":["OAuth2"],
+  "authSchemas":["OAuth2","AgentIdentity"],
   "audience": "4500ebfb-89b6-4b14-a480-7f749797bfcd",
   "customProperties": { "x-ms-preview": true }
 }

--- a/partners/servers/microsoft-sentinel-knowledge-objects-mcp-server.json
+++ b/partners/servers/microsoft-sentinel-knowledge-objects-mcp-server.json
@@ -39,7 +39,7 @@
     }
   },
   "visibility": "true",
-  "authSchemas":["OAuth2"],
+  "authSchemas":["OAuth2","AgentIdentity"],
   "audience": "4500ebfb-89b6-4b14-a480-7f749797bfcd",
   "customProperties": { "x-ms-preview": true }
 }


### PR DESCRIPTION
With the following configurations, I was able to connect and execute Sentinel MCP tools using an agent identity with Security Reader role.

<img width="1443" height="752" alt="image" src="https://github.com/user-attachments/assets/2441f51f-04f0-464e-b86d-9722ad348c99" />

This flow was unblocked when authenticating with Sentinel MCP after 5/1, and we'd like for this to be an authentication option.