### PR TITLE
Support Project Managed Identity for Azure DevOps MCP Server

### DIFF
--- a/partners/servers/azure-devops-mcp-server.json
+++ b/partners/servers/azure-devops-mcp-server.json
@@ -58,7 +58,7 @@
       "scopes": ["2a72489c-aab2-4b65-b93a-a91edccf33b8/Ado.Mcp.Tools"]
     }
   },
-  "authSchemas":["OAuth2"],
+  "authSchemas":["OAuth2", "ManagedIdentity"],
   "audience": "api://2a72489c-aab2-4b65-b93a-a91edccf33b8",
   "versionName": "original",
   "customProperties": { "x-ms-preview": true }


### PR DESCRIPTION
Adds Managed Identity as an option for the Azure DevOps MCP server. This has been tested manually by adding the connection via REST API and the connection works as expected using the Foundry project's MI