### PR TITLE
Updated LSEG MCP name to reflect partner brand

### DIFF
--- a/partners/servers/lseg-mcp-server.json
+++ b/partners/servers/lseg-mcp-server.json
@@ -1,6 +1,6 @@
 {
   "name": "lseg",
-  "title": "LSEG Pricing & Analytics MCP Server",
+  "title": "LSEG Data and Analytics",
   "summary": "MCP server providing LSEG pricing, curves, volatility surfaces, QA macro and fundamentals, news, and time-series analytics for capital markets workflows.",
   "description": "This MCP server exposes LSEG analytics and market data for capital markets workflows, including FX spot and forward pricing, bond and bond futures valuation, options and interest rate swaps, interest rate, credit, inflation and FX forward curves, FX and equity volatility surfaces, QA IBES consensus and actuals, QA macroeconomic time series, QA company fundamentals, Insight news headlines, and TSCC interday pricing summaries, enabling valuation, risk, research, and reporting use cases directly from Azure-hosted AI agents.",
   "kind": "mcp",


### PR DESCRIPTION
This pull request makes a minor update to the LSEG MCP server configuration: 

- Changed the `title` in `partners/servers/lseg-mcp-server.json` from "LSEG Pricing & Analytics MCP Server" to "LSEG Data and Analytics" to meet partner branding requirements