### PR TITLE
Removed authSchema property on LSEG MCP manifest

### DIFF
--- a/partners/servers/lseg-mcp-server.json
+++ b/partners/servers/lseg-mcp-server.json
@@ -117,9 +117,6 @@
      "scopes": []
    }
   },
-  "authSchemas": [
-    "OAuth2"
-  ],
   "customProperties": { "x-ms-preview": true },
   "connectorName": "foundrylsegmcp"
 }


### PR DESCRIPTION
Removes `authSchemas` from the LSEG MCP server manifest. That value indicates Microsoft-managed authentication, but LSEG’s authentication does not use Microsoft-managed auth, so the manifest was incorrectly advertising the auth model. This was causing issues when Foundry agents attempted to utilize LSEG's MCP tool. 