### PR TITLE
Mark Work IQ MCP server as GA

### DIFF
--- a/partners/servers/workiq-mcp-server.json
+++ b/partners/servers/workiq-mcp-server.json
@@ -2,7 +2,7 @@
   "name": "microsoft-work-iq-mcp-frontier",
   "title": "Work IQ MCP",
   "summary": "Work IQ MCP Server exposes Microsoft Graph as MCP tools for AI agents. Learn more at https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/work-iq-api-overview",
-  "description": "The Work IQ MCP Server exposes Microsoft Graph as a set of tools for AI agents — read, create, update, and delete M365 entities (mail, calendar, files, chats, and more), search and retrieve OpenAPI schemas, list available agents, and ask M365 Copilot or route requests to specific A2A agents. This feature is in preview and is part of the Work IQ tools, providing shared work intelligence and actions for agents. Availability and capabilities are subject to change. Learn more: https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/work-iq-api-overview",
+  "description": "The Work IQ MCP Server exposes Microsoft Graph as a set of tools for AI agents — read, create, update, and delete M365 entities (mail, calendar, files, chats, and more), search and retrieve OpenAPI schemas, list available agents, and ask M365 Copilot or route requests to specific A2A agents. This is part of the Work IQ tools, providing shared work intelligence and actions for agents. Learn more: https://learn.microsoft.com/en-us/microsoft-365/copilot/extensibility/work-iq-api-overview",
   "kind": "mcp",
   "vendor": "Microsoft",
   "externalDocumentation": {
@@ -76,6 +76,6 @@
   },
   "audience": "fdcc1f02-fc51-4226-8753-f668596af7f7",
   "versionName": "original",
-  "customProperties": { "x-ms-preview": true },
+  "customProperties": { "x-ms-preview": false },
   "tags": ["workiq"]
 }


### PR DESCRIPTION
## Summary
- Set `x-ms-preview` to `false` in `workiq-mcp-server.json` to remove the preview badge in Foundry
- Removed preview language ("This feature is in preview...Availability and capabilities are subject to change.") from the description

## Test plan
- [ ] Verify the preview tag no longer appears on the Work IQ MCP entry in Foundry after this change is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)