### PR TITLE
Add Druva MCP Server to partner registry

### DIFF
--- a/partners/servers/druva-mcp-server.json
+++ b/partners/servers/druva-mcp-server.json
@@ -1,0 +1,56 @@
+{
+  "name": "druva-mcp-server",
+  "title": "Druva",
+  "summary": "Manage backups, audit logs, and environment metrics across the Druva Resilience Cloud using natural language.",
+  "description": "The official Druva MCP Server connects AI agents to the Druva Resilience Cloud over a secure remote HTTP connection. Agents can discover Druva capabilities as skills, fetch data from your environment, and perform non-destructive actions to manage backup and data protection. Use it to query backup and recovery status across endpoints, SaaS apps, and cloud workloads. Also, review audit logs, and monitor environment metrics through natural language.",
+  "kind": "mcp",
+  "license": {
+    "name": "Druva Terms of Service",
+    "url": "https://www.druva.com/terms-of-service"
+  },
+  "icon": "https://avatars.githubusercontent.com/druvainc?s=64",
+  "externalDocumentation": {
+    "title": "Complete Guide to Druva MCP Server",
+    "url": "https://help.druva.com/en/articles/15654265-complete-guide-to-druva-mcp-server"
+  },
+  "remote": "https://mcp-us.druva.com/mcp",
+  "remoteType": "streamable-http",
+  "useCases": [
+    {
+      "name": "Backup & Recovery Insights",
+      "description": "Query backup coverage, job outcomes, and recovery status across endpoints, Microsoft 365, and cloud workloads using natural language."
+    },
+    {
+      "name": "Environment Management",
+      "description": "Perform non-destructive management actions in your Druva environment via read and write skills; the server cannot delete configurations or backup data."
+    },
+    {
+      "name": "Audit & Compliance",
+      "description": "Review audit logs and activity across the Druva Resilience Cloud to support governance, compliance, and investigation workflows."
+    },
+    {
+      "name": "Monitoring & Reporting",
+      "description": "Monitor environment metrics such as protection health and storage consumption, and surface reporting insights on demand."
+    }
+  ],
+  "tags": [
+    "backup",
+    "data-protection",
+    "recovery",
+    "ransomware",
+    "cyber-resilience",
+    "audit-logs"
+  ],
+  "vendor": "Partner",
+  "categories": "Storage, Security",
+  "visibility": "true",
+  "authSchemas": [
+    "OAuth2"
+  ],
+  "versionName": "original",
+  "supportContactInfo": {
+    "name": "Druva Support",
+    "url": "https://support.druva.com/"
+  },
+  "customProperties": { "x-ms-preview": false }
+}


### PR DESCRIPTION
## Summary

This PR lists the official **Druva MCP Server** in the partner registry (`partners/servers/druva-mcp-server.json`).

The Druva MCP Server is a remote, streamable-HTTP server that connects AI agents to the **Druva Resilience Cloud**, enabling natural-language management of backups, audit logs, and environment metrics.

## Details

- **Vendor:** Druva (Partner)
- **Transport:** `streamable-http` (remote hosted, no local install)
- **Endpoint:** `https://mcp-us.druva.com/mcp`
- **Auth:** 3-legged OAuth 2.1 via the Druva Console (`authSchemas: ["OAuth2"]`)
- **Categories:** Storage, Security
- **Availability:** Generally available (`x-ms-preview: false`)
- **Docs:** [Complete Guide to Druva MCP Server](https://help.druva.com/en/articles/15654265-complete-guide-to-druva-mcp-server)

The entry conforms to `partners/server-schema.json` (all required fields present; enums and length limits validated).

