### PR TITLE
Add Tako MCP server

### DIFF
--- a/partners/servers/tako-mcp-server.json
+++ b/partners/servers/tako-mcp-server.json
@@ -1,0 +1,97 @@
+{
+  "name": "tako-mcp-server",
+  "title": "Tako Knowledge Layer and Web Search",
+  "summary": "The knowledge layer for agents: proprietary structured data from trusted providers plus full web search, returning typed values with named sources, as-of dates, charts, and exportable rows.",
+  "description": "The knowledge layer for agents, grounding your AI with the most accurate proprietary data and web content. Tako grounds an agent in two kinds of knowledge at once: proprietary structured data from trusted providers, and full web search. One API returns typed values with named sources when curated data exists, and agent-ready web results and page text for everything else. Domains Tako covers with proprietary data: finance and markets, company KPIs and earnings, macroeconomics (inflation, unemployment, GDP, policy rates), website and app traffic, sports, weather, elections, prediction markets, demographics, energy, and real estate. Because Tako searches the live web too, it is a superset of a web-search tool rather than another one. Ask what the web says about X and you get web results. Ask what X's number is and you also get the value, the source it came from, its as-of date, a renderable chart, and exportable rows, rather than excerpts to parse.",
+  "kind": "mcp",
+  "license": {
+    "name": "MIT",
+    "url": "https://github.com/TakoData/tako-mcp/blob/main/LICENSE"
+  },
+  "icon": "https://raw.githubusercontent.com/TakoData/tako-mcp/main/docs/branding/tako-icon-180.png",
+  "externalDocumentation": {
+    "title": "Tako MCP Server Documentation",
+    "url": "https://docs.tako.com/documentation/integrations/mcp-server"
+  },
+  "repository": {
+    "url": "https://github.com/TakoData/tako-mcp",
+    "source": "github"
+  },
+  "remote": "https://mcp.tako.com/mcp",
+  "remoteType": "streamable-http",
+  "useCases": [
+    {
+      "name": "Company financials and equity research",
+      "description": "Pull revenue, earnings versus estimates, margins, valuation multiples, and stock performance for public companies, and compare competitors head to head. Results come back as citation-backed charts with the underlying series attached, so agents can reason over the numbers instead of scraping filings."
+    },
+    {
+      "name": "Macroeconomic monitoring and briefings",
+      "description": "Track inflation (CPI and PCE), unemployment, GDP, policy and interest rates, and other indicators across countries from sources such as FRED, OECD, and BIS. Useful for automated economic briefings, market commentary, and macro-aware forecasting agents."
+    },
+    {
+      "name": "Web and app traffic benchmarking",
+      "description": "Retrieve monthly visits, traffic trends, and top-site rankings for any domain to power competitive analysis, share-of-attention reporting, and market sizing without standing up a separate analytics integration."
+    },
+    {
+      "name": "Live web search and page extraction",
+      "description": "Run real-time web searches and read the full text behind any result URL. Because a single Tako call searches both the proprietary data graph and the live web, one tool call covers questions that mix hard numbers with narrative context."
+    },
+    {
+      "name": "Data coverage discovery",
+      "description": "Ask, at no cost, what proprietary data Tako holds for a given entity or metric and get the exact measure names back. Agents use this to ground a question in data that actually exists before spending a priced call, which cuts hallucinated metrics and wasted retries."
+    },
+    {
+      "name": "Chart generation and embedding",
+      "description": "Turn Tako results, or an agent's own structured data, into an embeddable interactive chart. Downstream applications can render the visualization inline in chat, dashboards, or reports."
+    }
+  ],
+  "tags": [
+    "search",
+    "web-search",
+    "finance",
+    "market-data",
+    "macroeconomics",
+    "economic-indicators",
+    "web-traffic",
+    "sports",
+    "weather",
+    "data-visualization",
+    "charts",
+    "real-time-data",
+    "grounding",
+    "research"
+  ],
+  "vendor": "Partner",
+  "visibility": "public",
+  "categories": "Finance",
+  "versionName": "original",
+  "securitySchemes": {
+    "takoOauth2": {
+      "type": "oauth2",
+      "description": "OAuth 2.1 authorization code flow with PKCE and Dynamic Client Registration for delegated user sign-in to a Tako account.",
+      "authorizationUrl": "https://mcp.tako.com/authorize",
+      "tokenUrl": "https://mcp.tako.com/token",
+      "refreshUrl": "https://mcp.tako.com/token",
+      "scopes": [
+        "mcp"
+      ],
+      "flows": [
+        "authorizationCode"
+      ]
+    },
+    "takoBearerAuth": {
+      "type": "http",
+      "description": "Authenticate with a Tako API key, issued at https://tako.com/console/api-keys, sent as a bearer token.",
+      "scheme": "bearer",
+      "bearerFormat": "Tako API key"
+    }
+  },
+  "supportContactInfo": {
+    "name": "Tako Support",
+    "email": "hello@tako.com",
+    "url": "https://docs.tako.com/documentation/integrations/mcp-server"
+  },
+  "customProperties": {
+    "x-ms-preview": false
+  }
+}


### PR DESCRIPTION
## Add Tako MCP server

This PR adds a single new partner entry, `partners/servers/tako-mcp-server.json`, registering the Tako MCP server for the **Microsoft Foundry Tools Catalog** and the **Azure API Center MCP Registry**. No other files are touched.

### What Tako is

The knowledge layer for agents, grounding your AI with the most accurate proprietary data and web content.

Tako grounds your agent in two kinds of knowledge at once: proprietary structured data from trusted providers, and full web search. One API returns typed values with named sources when curated data exists, and agent-ready web results and page text for everything else.

**Domains Tako covers with proprietary data:** finance and markets, company KPIs and earnings, macroeconomics (inflation, unemployment, GDP, policy rates), website and app traffic, sports, weather, elections, prediction markets, demographics, energy, real estate.

**Why this is additive rather than a fourth web-search vendor:** Tako searches the live web too, so it already covers what existing web-search tools cover. The difference is what arrives on top of that. Ask "what does the web say about X" and you get web results, same as anywhere. Ask "what is X's number" and you also get the value, the source it came from, its as-of date, a renderable chart, and exportable rows — rather than excerpts to parse. It's a superset, and it's the tool for the query class where a model plus web excerpts currently produces a confidently wrong figure.

- **Hosted endpoint:** `https://mcp.tako.com/mcp` (streamable HTTP, no install required)
- **Docs:** https://docs.tako.com/documentation/integrations/mcp-server
- **Source:** https://github.com/TakoData/tako-mcp (MIT)

### Authentication

Both schemes declared in the entry are live in production today:

| Scheme | Detail |
| --- | --- |
| `takoOauth2` | OAuth 2.1 authorization code + PKCE with Dynamic Client Registration. Endpoints published at [`/.well-known/oauth-authorization-server`](https://mcp.tako.com/.well-known/oauth-authorization-server); scope `mcp`. |
| `takoBearerAuth` | Tako API key sent as a bearer token. Keys issued at https://tako.com/console/api-keys. |

Connecting without credentials lands on a free tier, so the server is exercisable from the catalog before a customer signs up.

### Validation

All three jobs from `.github/workflows/validate-servers.yml` were run locally against the full `partners/servers/` directory before opening this PR:

```
$ check-jsonschema --verbose --schemafile partners/server-schema.json partners/servers/*.json
ok -- validation done

$ # server name uniqueness
All 96 server names are unique across JSON files

$ # security scheme key uniqueness
All 107 security scheme keys are unique across JSON files
```

Additional checks:

- Every required property from `partners/server-schema.json` is present; every `maxLength`, `pattern`, and `enum` constraint verified.
- `categories` uses the supported value `Finance`.
- `vendor` is `Partner`; `customProperties.x-ms-preview` is `false` (the server is generally available at v0.17.0).
- Server name `tako-mcp-server` and security scheme keys `takoOauth2` / `takoBearerAuth` do not collide with any existing entry.
- Every URL in the entry (icon, license, documentation, repository, remote, OAuth endpoints, support) returns HTTP 200.

### Contact

Tako Support — hello@tako.com. Happy to make any changes the review process calls for.
